### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/MIME/Types.pm6
+++ b/lib/MIME/Types.pm6
@@ -1,6 +1,6 @@
 use v6;
 
-class MIME::Types;
+unit class MIME::Types;
 
 has %.exts;
 has %.types;


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.